### PR TITLE
Added free mouse position tracking to OsWindow

### DIFF
--- a/common/wsi/Mouse.hpp
+++ b/common/wsi/Mouse.hpp
@@ -11,8 +11,10 @@ struct Mouse
 {
   std::array<ButtonState, static_cast<std::size_t>(MouseButton::COUNT)> buttons{ButtonState::Low};
 
+  glm::vec2 freePos = {0, 0};
+
   // Provided on a per-frame basis, but only when mouse is captured.
-  glm::vec2 posDelta = {0, 0};
+  glm::vec2 capturedPosDelta = {0, 0};
 
   // Horizontal scroll is a thing on touchpads
   glm::vec2 scrollDelta = {0, 0};

--- a/common/wsi/OsWindowingManager.cpp
+++ b/common/wsi/OsWindowingManager.cpp
@@ -161,7 +161,7 @@ void OsWindowingManager::updateWindow(OsWindow& window)
       glfwGetCursorPos(window.impl, &x, &y);
       glfwSetCursorPos(window.impl, 0, 0);
 
-      window.mouse.posDelta = {x, y};
+      window.mouse.capturedPosDelta = {x, y};
     }
     else
     {
@@ -169,10 +169,18 @@ void OsWindowingManager::updateWindow(OsWindow& window)
       glfwSetCursorPos(window.impl, 0, 0);
       window.mouseWasCaptured = true;
     }
+
+    window.mouse.freePos = {0, 0};
   }
   else
   {
     glfwSetInputMode(window.impl, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
     window.mouseWasCaptured = false;
+
+    double x;
+    double y;
+    glfwGetCursorPos(window.impl, &x, &y);
+    window.mouse.freePos = {x, y};
+    window.mouse.capturedPosDelta = {0, 0};
   }
 }

--- a/samples/shadowmap/App.cpp
+++ b/samples/shadowmap/App.cpp
@@ -129,7 +129,7 @@ void App::rotateCam(Camera& cam, const Mouse& ms, float /*dt*/)
   // TODO: should dt be accounted for here?
 
   // Rotate camera based on mouse movement
-  cam.rotate(camRotateSpeed * ms.posDelta.y, camRotateSpeed * ms.posDelta.x);
+  cam.rotate(camRotateSpeed * ms.capturedPosDelta.y, camRotateSpeed * ms.capturedPosDelta.x);
 
   // Increase or decrease field of view based on mouse wheel
   cam.fov -= zoomSensitivity * ms.scrollDelta.y;


### PR DESCRIPTION
- Added freePos to mouse which tracks it's position in free cursor mode. Could be useful for more UI-style controls, and maps better to shadertoy's iMouse, if people were to use it that way.
- Renamed posDelta to capturedPosDelta to underline that it is only non-zero when mouse is captured.