### PR TITLE
Supress 4324 warning in MSVC build

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") # cl and clang-cl
   add_compile_options(/W4 /WX
     # Selectively disable some insane warnings
-    /wd4061 /wd4514
+    /wd4061 /wd4514 /wd4324
     # Enforce standards-compliance in MSVC
     /permissive- /volatile:iso /Zc:inline /Zc:wchar_t /EHsc /Zc:__cplusplus
   )


### PR DESCRIPTION
4324 is info about structure padding by using alignas specificator. This causes  compilation error when using alignas (due to treating warnings as error)